### PR TITLE
Re-export header-only functions from liburing

### DIFF
--- a/rusturing.c
+++ b/rusturing.c
@@ -4,3 +4,185 @@ extern inline void rust_io_uring_cq_advance(struct io_uring *ring, unsigned nr)
 {
     io_uring_cq_advance(ring, nr);
 }
+
+extern inline void rust_io_uring_cqe_seen(struct io_uring *ring, struct io_uring_cqe *cqe)
+{
+    io_uring_cqe_seen(ring, cqe);
+}
+
+extern inline void rust_io_uring_sqe_set_data(struct io_uring_sqe *sqe, void *data)
+{
+    io_uring_sqe_set_data(sqe, data);
+}
+
+extern inline void *rust_io_uring_cqe_get_data(struct io_uring_cqe *cqe)
+{
+    return io_uring_cqe_get_data(cqe);
+}
+
+extern inline void rust_io_uring_sqe_set_flags(struct io_uring_sqe *sqe, unsigned flags)
+{
+    io_uring_sqe_set_flags(sqe, flags);
+}
+
+extern inline void rust_io_uring_prep_rw(int op,
+                                         struct io_uring_sqe *sqe,
+                                         int fd,
+                                         const void *addr,
+                                         unsigned len,
+                                         off_t offset)
+{
+    io_uring_prep_rw(op, sqe, fd, addr, len, offset);
+}
+
+extern inline void rust_io_uring_prep_readv(struct io_uring_sqe *sqe,
+                                            int fd,
+                                            const struct iovec *iovecs,
+                                            unsigned nr_vecs,
+                                            off_t offset)
+{
+    io_uring_prep_readv(sqe, fd, iovecs, nr_vecs, offset);
+}
+
+extern inline void rust_io_uring_prep_read_fixed(struct io_uring_sqe *sqe,
+                                                 int fd,
+                                                 void *buf,
+                                                 unsigned nbytes,
+                                                 off_t offset,
+                                                 int buf_index)
+{
+    io_uring_prep_read_fixed(sqe, fd, buf, nbytes, offset, buf_index);
+}
+
+extern inline void rust_io_uring_prep_writev(struct io_uring_sqe *sqe,
+                                             int fd,
+                                             const struct iovec *iovecs,
+                                             unsigned nr_vecs,
+                                             off_t offset)
+{
+    io_uring_prep_writev(sqe, fd, iovecs, nr_vecs, offset);
+}
+
+extern inline void rust_io_uring_prep_write_fixed(struct io_uring_sqe *sqe,
+                                                  int fd,
+                                                  const void *buf,
+                                                  unsigned nbytes,
+                                                  off_t offset,
+                                                  int buf_index)
+{
+    io_uring_prep_write_fixed(sqe, fd, buf, nbytes, offset, buf_index);
+}
+
+extern inline void rust_io_uring_prep_recvmsg(struct io_uring_sqe *sqe,
+                                              int fd,
+                                              struct msghdr *msg,
+                                              unsigned flags)
+{
+    io_uring_prep_recvmsg(sqe, fd, msg, flags);
+}
+
+extern inline void rust_io_uring_prep_sendmsg(struct io_uring_sqe *sqe,
+                                              int fd,
+                                              const struct msghdr *msg,
+                                              unsigned flags)
+{
+    io_uring_prep_sendmsg(sqe, fd, msg, flags);
+}
+
+extern inline void rust_io_uring_prep_poll_add(struct io_uring_sqe *sqe, int fd, short poll_mask)
+{
+    io_uring_prep_poll_add(sqe, fd, poll_mask);
+}
+
+extern inline void rust_io_uring_prep_poll_remove(struct io_uring_sqe *sqe, void *user_data)
+{
+    io_uring_prep_poll_remove(sqe, user_data);
+}
+
+extern inline void rust_io_uring_prep_fsync(struct io_uring_sqe *sqe, int fd, unsigned fsync_flags)
+{
+    io_uring_prep_fsync(sqe, fd, fsync_flags);
+}
+
+extern inline void rust_io_uring_prep_nop(struct io_uring_sqe *sqe)
+{
+    io_uring_prep_nop(sqe);
+}
+
+extern inline void rust_io_uring_prep_timeout(struct io_uring_sqe *sqe,
+                                              struct __kernel_timespec *ts,
+                                              unsigned count,
+                                              unsigned flags)
+{
+    io_uring_prep_timeout(sqe, ts, count, flags);
+}
+
+extern inline void rust_io_uring_prep_timeout_remove(struct io_uring_sqe *sqe,
+                                                     __u64 user_data,
+                                                     unsigned flags)
+{
+    io_uring_prep_timeout_remove(sqe, user_data, flags);
+}
+
+extern inline void rust_io_uring_prep_accept(struct io_uring_sqe *sqe,
+                                             int fd,
+                                             struct sockaddr *addr,
+                                             socklen_t *addrlen,
+                                             int flags)
+{
+    io_uring_prep_accept(sqe, fd, addr, addrlen, flags);
+}
+
+extern inline void rust_io_uring_prep_cancel(struct io_uring_sqe *sqe,
+                                             void *user_data,
+                                             int flags)
+{
+    io_uring_prep_cancel(sqe, user_data, flags);
+}
+
+extern inline void rust_io_uring_prep_link_timeout(struct io_uring_sqe *sqe,
+                                                   struct __kernel_timespec *ts,
+                                                   unsigned flags)
+{
+    io_uring_prep_link_timeout(sqe, ts, flags);
+}
+
+extern inline void rust_io_uring_prep_connect(struct io_uring_sqe *sqe,
+                                              int fd,
+                                              struct sockaddr *addr,
+                                              socklen_t addrlen)
+{
+    io_uring_prep_connect(sqe, fd, addr, addrlen);
+}
+
+extern inline unsigned rust_io_uring_sq_ready(struct io_uring *ring)
+{
+    return io_uring_sq_ready(ring);
+}
+
+extern inline unsigned rust_io_uring_sq_space_left(struct io_uring *ring)
+{
+    return io_uring_sq_space_left(ring);
+}
+
+extern inline unsigned rust_io_uring_cq_ready(struct io_uring *ring)
+{
+    return io_uring_cq_ready(ring);
+}
+
+extern inline int rust_io_uring_wait_cqe_nr(struct io_uring *ring,
+                                            struct io_uring_cqe **cqe_ptr,
+                                            unsigned wait_nr)
+{
+    return io_uring_wait_cqe_nr(ring, cqe_ptr, wait_nr);
+}
+
+extern inline int rust_io_uring_peek_cqe(struct io_uring *ring, struct io_uring_cqe **cqe_ptr)
+{
+    return io_uring_peek_cqe(ring, cqe_ptr);
+}
+
+extern inline int rust_io_uring_wait_cqe(struct io_uring *ring, struct io_uring_cqe **cqe_ptr)
+{
+    return io_uring_wait_cqe(ring, cqe_ptr);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -228,5 +228,166 @@ extern {
 
 #[link(name = "rusturing")]
 extern {
-    pub fn rust_io_uring_cq_advance(ring: *mut io_uring, nr: libc::c_uint);
+    #[link_name = "rust_io_uring_cq_advance"]
+    pub fn io_uring_cq_advance(ring: *mut io_uring, nr: libc::c_uint);
+
+    #[link_name = "rust_io_uring_cqe_seen"]
+    pub fn io_uring_cqe_seen(ring: *mut io_uring, cqe: *mut io_uring_cqe);
+
+    #[link_name = "rust_io_uring_sqe_set_data"]
+    pub fn io_uring_sqe_set_data(sqe: *mut io_uring_sqe, data: *mut libc::c_void);
+
+    #[link_name = "rust_io_uring_cqe_get_data"]
+    pub fn io_uring_cqe_get_data(cqe: *mut io_uring_cqe) -> *mut libc::c_void;
+
+    #[link_name = "rust_io_uring_sqe_set_flags"]
+    pub fn io_uring_sqe_set_flags(sqe: *mut io_uring_sqe, flags: libc::c_uint);
+
+    #[link_name = "rust_io_uring_prep_rw"]
+    pub fn io_uring_prep_rw(
+        op: libc::c_int,
+        sqe: *mut io_uring_sqe,
+        fd: libc::c_int,
+        addr: *const libc::c_void,
+        len: libc::c_uint,
+        offset: libc::off_t,
+    );
+
+    #[link_name = "rust_io_uring_prep_readv"]
+    pub fn io_uring_prep_readv(
+        sqe: *mut io_uring_sqe,
+        fd: libc::c_int,
+        iovecs: *const libc::iovec,
+        nr_vecs: libc::c_uint,
+        offset: libc::off_t,
+    );
+
+    #[link_name = "rust_io_uring_prep_read_fixed"]
+    pub fn io_uring_prep_read_fixed(
+        sqe: *mut io_uring_sqe,
+        fd: libc::c_int,
+        buf: *mut libc::c_void,
+        nbytes: libc::c_uint,
+        offset: libc::off_t,
+        buf_index: libc::c_int,
+    );
+
+    #[link_name = "rust_io_uring_prep_writev"]
+    pub fn io_uring_prep_writev(
+        sqe: *mut io_uring_sqe,
+        fd: libc::c_int,
+        iovecs: *const libc::iovec,
+        nr_vecs: libc::c_uint,
+        offset: libc::off_t,
+    );
+
+    #[link_name = "rust_io_uring_prep_write_fixed"]
+    pub fn io_uring_prep_write_fixed(
+        sqe: *mut io_uring_sqe,
+        fd: libc::c_int,
+        buf: *const libc::c_void,
+        nbytes: libc::c_uint,
+        offset: libc::off_t,
+        buf_index: libc::c_int,
+    );
+
+    #[link_name = "rust_io_uring_prep_recvmsg"]
+    pub fn io_uring_prep_recvmsg(
+        sqe: *mut io_uring_sqe,
+        fd: libc::c_int,
+        msg: *mut libc::msghdr,
+        flags: libc::c_uint,
+    );
+
+    #[link_name = "rust_io_uring_prep_sendmsg"]
+    pub fn io_uring_prep_sendmsg(
+        sqe: *mut io_uring_sqe,
+        fd: libc::c_int,
+        msg: *const libc::msghdr,
+        flags: libc::c_uint,
+    );
+
+    #[link_name = "rust_io_uring_prep_poll_add"]
+    pub fn io_uring_prep_poll_add(
+        sqe: *mut io_uring_sqe,
+        fd: libc::c_int,
+        poll_mask: libc::c_short,
+    );
+
+    #[link_name = "rust_io_uring_prep_poll_remove"]
+    pub fn io_uring_prep_poll_remove(sqe: *mut io_uring_sqe, user_data: *mut libc::c_void);
+
+    #[link_name = "rust_io_uring_prep_fsync"]
+    pub fn io_uring_prep_fsync(sqe: *mut io_uring_sqe, fd: libc::c_int, fsync_flags: libc::c_uint);
+
+    #[link_name = "rust_io_uring_prep_nop"]
+    pub fn io_uring_prep_nop(sqe: *mut io_uring_sqe);
+
+    #[link_name = "rust_io_uring_prep_timeout"]
+    pub fn io_uring_prep_timeout(
+        sqe: *mut io_uring_sqe,
+        ts: *mut __kernel_timespec,
+        count: libc::c_uint,
+        flags: libc::c_uint,
+    );
+
+    #[link_name = "rust_io_uring_prep_timeout_remove"]
+    pub fn io_uring_prep_timeout_remove(
+        sqe: *mut io_uring_sqe,
+        user_data: libc::__u64,
+        flags: libc::c_uint,
+    );
+
+    #[link_name = "rust_io_uring_prep_accept"]
+    pub fn io_uring_prep_accept(
+        sqe: *mut io_uring_sqe,
+        fd: libc::c_int,
+        addr: *mut libc::sockaddr,
+        addrlen: *mut libc::socklen_t,
+        flags: libc::c_int,
+    );
+
+    #[link_name = "rust_io_uring_prep_cancel"]
+    pub fn io_uring_prep_cancel(
+        sqe: *mut io_uring_sqe,
+        user_data: *mut libc::c_void,
+        flags: libc::c_int,
+    );
+
+    #[link_name = "rust_io_uring_prep_link_timeout"]
+    pub fn io_uring_prep_link_timeout(
+        sqe: *mut io_uring_sqe,
+        ts: *mut __kernel_timespec,
+        flags: libc::c_uint,
+    );
+
+    #[link_name = "rust_io_uring_prep_connect"]
+    pub fn io_uring_prep_connect(
+        sqe: *mut io_uring_sqe,
+        fd: libc::c_int,
+        addr: *mut libc::sockaddr,
+        addrlen: libc::socklen_t,
+    );
+
+    #[link_name = "rust_io_uring_sq_ready"]
+    pub fn io_uring_sq_ready(ring: *mut io_uring) -> libc::c_uint;
+
+    #[link_name = "rust_io_uring_sq_space_left"]
+    pub fn io_uring_sq_space_left(ring: *mut io_uring) -> libc::c_uint;
+
+    #[link_name = "rust_io_uring_cq_ready"]
+    pub fn io_uring_cq_ready(ring: *mut io_uring) -> libc::c_uint;
+
+    #[link_name = "rust_io_uring_wait_cqe_nr"]
+    pub fn io_uring_wait_cqe_nr(
+        ring: *mut io_uring,
+        cqe_ptr: *mut *mut io_uring_cqe,
+        wait_nr: libc::c_uint,
+    ) -> libc::c_int;
+
+    #[link_name = "rust_io_uring_peek_cqe"]
+    pub fn io_uring_peek_cqe(ring: *mut io_uring, cqe_ptr: *mut *mut io_uring_cqe) -> libc::c_int;
+
+    #[link_name = "rust_io_uring_wait_cqe"]
+    pub fn io_uring_wait_cqe(ring: *mut io_uring, cqe_ptr: *mut *mut io_uring_cqe) -> libc::c_int;
 }


### PR DESCRIPTION
Closes #4. This will allow us in iou to delegate all of the prep APIs to liburing instead of being responsible for setting SQEs up correctly.

@twissel would you be open to doing a quick review of this code to check that I didn't get any argument or return types wrong?