### PR TITLE
fix return value for io_uring_peek_batch_cqe

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -294,7 +294,7 @@ extern {
         ring: *mut io_uring,
         cqes: *mut *mut io_uring_cqe,
         count: libc::c_uint
-    ) -> libc::c_uint;
+    ) -> libc::c_int;
 
     pub fn io_uring_wait_cqes(
         ring: *mut io_uring,


### PR DESCRIPTION
io_uring_peek_batch_cqe return an integer (signed) but it is signature
in this crate expects an unsigned integer.

I found this bug while using iou, in which the following code breaks:

pub fn peek_for_cqe(&mut self) -> Option<CompletionQueueEvent> {
    let mut cqe = MaybeUninit::uninit();
    let count = uring_sys::io_uring_peek_batch_cqe(&mut self.ring, cqe.as_mut_ptr(), 1);

    if count > 0 { <===== return is 0xfffff....
	Some(CompletionQueueEvent::new(NonNull::from(&self.ring), &mut *cqe.assume_init()))
    } else {
	None   <==== never reached
    }
}