### PR TITLE
derive Debug on IoUringOp

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub const LIBURING_UDATA_TIMEOUT: libc::__u64 = libc::__u64::max_value();
 #[repr(C)]
 #[non_exhaustive]
 #[allow(nonstandard_style)]
+#[derive(Debug)]
 pub enum IoRingOp {
     IORING_OP_NOP,
     IORING_OP_READV,


### PR DESCRIPTION
This is useful if we want to print the opcodes in debug messages in
case something fails.
