### PR TITLE
Make IoRingOp Copy

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ pub const LIBURING_UDATA_TIMEOUT: libc::__u64 = libc::__u64::max_value();
 #[repr(C)]
 #[non_exhaustive]
 #[allow(nonstandard_style)]
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub enum IoRingOp {
     IORING_OP_NOP,
     IORING_OP_READV,


### PR DESCRIPTION
This is useful to be able to cast this to int without consuming