### PR TITLE
Tee up future liburing 0.8 sqe_prep functions

### DIFF
--- a/rusturing.c
+++ b/rusturing.c
@@ -285,6 +285,19 @@ extern inline void rust_io_uring_prep_shutdown(struct io_uring_sqe *sqe, int fd,
 	io_uring_prep_shutdown(sqe, fd, how);
 }
 
+extern inline void rust_io_uring_prep_unlinkat(struct io_uring_sqe *sqe, int dfd,
+					  const char *path, int flags)
+{
+    io_uring_prep_unlinkat(sqe, dfd, path, flags);
+}
+
+extern inline void rust_io_uring_prep_renameat(struct io_uring_sqe *sqe, int olddfd,
+					  const char *oldpath, int newdfd,
+					  const char *newpath, int flags)
+{
+    io_uring_prep_renameat(sqe, olddfd, oldpath, newdfd, newpath, flags);
+}
+
 extern inline unsigned rust_io_uring_sq_ready(struct io_uring *ring)
 {
     return io_uring_sq_ready(ring);

--- a/rusturing.c
+++ b/rusturing.c
@@ -49,6 +49,14 @@ extern inline void rust_io_uring_prep_splice(struct io_uring_sqe *sqe,
     io_uring_prep_splice(sqe, fd_in, fd_out, off_in, off_out, nbytes, splice_flags);
 }
 
+extern inline void rust_io_uring_prep_tee(struct io_uring_sqe *sqe,
+				     int fd_in, int fd_out,
+				     unsigned int nbytes,
+				     unsigned int splice_flags)
+{
+    io_uring_prep_tee(sqe, fd_in, fd_out, nbytes, splice_flags);
+}
+
 extern inline void rust_io_uring_prep_readv(struct io_uring_sqe *sqe,
                                             int fd,
                                             const struct iovec *iovecs,

--- a/rusturing.c
+++ b/rusturing.c
@@ -279,6 +279,12 @@ extern inline void rust_io_uring_prep_remove_buffers(struct io_uring_sqe *sqe,
     io_uring_prep_remove_buffers(sqe, nr, bgid);
 }
 
+extern inline void rust_io_uring_prep_shutdown(struct io_uring_sqe *sqe, int fd,
+					  int how)
+{
+	io_uring_prep_shutdown(sqe, fd, how);
+}
+
 extern inline unsigned rust_io_uring_sq_ready(struct io_uring *ring)
 {
     return io_uring_sq_ready(ring);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,7 @@ pub enum IoRingOp {
     IORING_OP_PROVIDE_BUFFERS,
     IORING_OP_REMOVE_BUFFERS,
     IORING_OP_TEE,
+    IORING_OP_SHUTDOWN,
 }
 
 // sqe.flags
@@ -658,6 +659,13 @@ extern {
         sqe: *mut io_uring_sqe,
         nr: libc::c_int,
         bgid: libc::c_int
+    );
+
+    #[link_name = "rust_io_uring_prep_shutdown"]
+    pub fn io_uring_prep_shutdown(
+        sqe: *mut io_uring_sqe,
+        fd: libc::c_int,
+        how: libc::c_int
     );
 
     #[link_name = "rust_io_uring_sq_ready"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -409,6 +409,15 @@ extern {
         splice_flags: libc::c_uint,
     );
 
+    #[link_name = "rust_io_uring_prep_tee"]
+    pub fn io_uring_prep_tee(
+        sqe: *mut io_uring_sqe,
+        fd_in: libc::c_int,
+        fd_out: libc::c_int,
+        nbytes: libc::c_uint,
+        splice_flags: libc::c_uint,
+    );
+
     #[link_name = "rust_io_uring_prep_readv"]
     pub fn io_uring_prep_readv(
         sqe: *mut io_uring_sqe,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,8 @@ pub enum IoRingOp {
     IORING_OP_REMOVE_BUFFERS,
     IORING_OP_TEE,
     IORING_OP_SHUTDOWN,
+    IORING_OP_RENAMEAT,
+    IORING_OP_UNLINKAT,
 }
 
 // sqe.flags
@@ -188,6 +190,8 @@ pub union cmd_flags {
     pub statx_flags: libc::__u32,
     pub fadvise_advice: libc::__u32,
     pub splice_flags: libc::__u32,
+    pub rename_flags: libc::__u32,
+    pub unlink_flags: libc::__u32,
 }
 
 #[allow(non_camel_case_types)]
@@ -666,6 +670,24 @@ extern {
         sqe: *mut io_uring_sqe,
         fd: libc::c_int,
         how: libc::c_int
+    );
+
+    #[link_name = "rust_io_uring_prep_unlinkat"]
+    pub fn io_uring_prep_unlinkat(
+        sqe: *mut io_uring_sqe,
+        dfd: libc::c_int,
+        path: *const libc::c_char,
+        flags: libc::c_int,
+    );
+
+    #[link_name = "rust_io_uring_prep_renameat"]
+    pub fn io_uring_prep_renameat(
+        sqe: *mut io_uring_sqe,
+        olddfd: libc::c_int,
+        oldpath: *const libc::c_char,
+        newdfd: libc::c_int,
+        newpath: *const libc::c_char,
+        flags: libc::c_int,
     );
 
     #[link_name = "rust_io_uring_sq_ready"]


### PR DESCRIPTION
Adds the future liburing 0.8 sqe_prep functions intended for integration once 0.8 is released and we bump our submodule.

The new syscall prep functions are: 
- `tee`
- `shutdown`
- `renameat`
- `unlinkat`